### PR TITLE
Small improvements

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,4 +7,10 @@ const argv = process.argv.slice(2)
 
 if (argv.indexOf('--version') !== -1 || argv.indexOf('-v') !== -1) version()
 if (argv.indexOf('--help') !== -1 || argv.indexOf('-h') !== -1) help()
+
+if (!bowerless.hasDependencies()) {
+	console.error('[error] Sorry, this script requires dependencies from your package.json')
+	process.exit(1)
+}
+
 bowerless(argv)

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ $ bowerless --help
 
     $ bowerless
     $ bowerless dist/lib
+    $ bowerless dist/lib my-bundle-name
 ```
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,8 @@ const dirname = path.resolve(__dirname, '../../..')
 const pkg = require(`${dirname}/package.json`)
 
 function bowerless (argv) {
-	const bundle = 'bundle.min'
 	const directory = argv[0] || dirname
+	const bundle = argv[1] || 'bundle.min'
 
 	createCache()
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-#!/usr/bin/env node
 'use strict'
+
 const fs = require('fs')
 const path = require('path')
 const shelljs = require('shelljs')
@@ -16,16 +16,13 @@ if (!pkg || !pkg.dependencies || !Object.keys(pkg.dependencies).length) {
 }
 
 function bowerless (argv) {
+	const bundle = 'bundle.min'
 	const directory = argv[0] || dirname
 
-	shelljs
-		.exec(`rm -rf node_modules/bowerless/.cache`)
-		.exec(`mkdir -p ${cache}`)
-		.exec(`cp -r package.json ${cache}/package.json`)
-		.exec(`cd ${cache} && npm i --prod --ignore-script`)
+	createCache()
 
-	if (fs.existsSync(`${directory}/bundle.min.js`)) fs.unlinkSync(`${directory}/bundle.min.js`)
-	if (fs.existsSync(`${directory}/bundle.min.css`)) fs.unlinkSync(`${directory}/bundle.min.css`)
+	if (fs.existsSync(`${directory}/${bundle}.js`)) fs.unlinkSync(`${directory}/${bundle}.js`)
+	if (fs.existsSync(`${directory}/${bundle}.css`)) fs.unlinkSync(`${directory}/${bundle}.css`)
 
 	const max = getDirectories(`${cache}/node_modules`).length
 	let count = 1
@@ -34,18 +31,26 @@ function bowerless (argv) {
 
 	if (!fs.existsSync(directory)) mkdirp.sync(directory)
 	globbies(path.resolve(`${cache}/node_modules/**/package.json`), file => {
-		let main = `${path.dirname(file)}/${require(file).main}`
+		const main = `${path.dirname(file)}/${require(file).main}`
 		if (path.extname(main) === '.css') cssBundle.push(main)
 		if (path.extname(main) === '.js') jsBundle.push(main)
 		if (max === count++) {
-			concat(cssBundle, `${directory}/bundle.min.css`)
-			concat(jsBundle, `${directory}/bundle.min.js`)
+			concat(cssBundle, `${directory}/${bundle}.css`)
+			concat(jsBundle, `${directory}/${bundle}.js`)
 		}
 	})
 }
 
 function getDirectories (srcpath) {
 	return fs.readdirSync(srcpath).filter(file => fs.statSync(path.join(srcpath, file)).isDirectory())
+}
+
+function createCache () {
+	shelljs
+		.exec(`rm -rf node_modules/bowerless/.cache`)
+		.exec(`mkdir -p ${cache}`)
+		.exec(`cp -r package.json ${cache}/package.json`)
+		.exec(`cd ${cache} && npm i --prod --ignore-script`)
 }
 
 module.exports = bowerless

--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,6 @@ const cache = path.resolve(__dirname, '../.cache')
 const dirname = path.resolve(__dirname, '../../..')
 const pkg = require(`${dirname}/package.json`)
 
-if (!pkg || !pkg.dependencies || !Object.keys(pkg.dependencies).length) {
-	console.error('[error] Sorry, this script requires dependencies from your package.json')
-	process.exit(1)
-}
-
 function bowerless (argv) {
 	const bundle = 'bundle.min'
 	const directory = argv[0] || dirname
@@ -45,6 +40,10 @@ function getDirectories (srcpath) {
 	return fs.readdirSync(srcpath).filter(file => fs.statSync(path.join(srcpath, file)).isDirectory())
 }
 
+function hasDependencies () {
+	return (pkg && pkg.dependencies && Object.keys(pkg.dependencies).length)
+}
+
 function createCache () {
 	shelljs
 		.exec(`rm -rf node_modules/bowerless/.cache`)
@@ -54,3 +53,4 @@ function createCache () {
 }
 
 module.exports = bowerless
+module.exports.hasDependencies = hasDependencies


### PR DESCRIPTION
- [x] removed `#!/usr/bin/env node` from `index.js`
- [x] moved all the \~cli-code-like\~ from `index.js` to `cli.js`
- [x] added support to set the bundle name. 👌  see an example below:

```
$ bowerless dist/libs external
```